### PR TITLE
Added HTTP endpoints linking to controller.

### DIFF
--- a/CoffeeMachine.ino
+++ b/CoffeeMachine.ino
@@ -3,6 +3,7 @@
 #include "I2CButton.h"
 #include "Controller.h"
 #include "PCF8574.h"
+#include "RequestsMgr.h"
 
 Controller controller(config_relayPin,
                       WiFiLink(config_ssid,
@@ -38,23 +39,21 @@ I2CButtonsMgr buttonsMgr(&offButton,
                          &readyButton,
                          &controller);
 
+RequestsMgr requestsMgr(config_serverPort, 
+                        &controller);
+
 void setup()
 {
   Serial.begin(115200);
   controller.setup();
   I2CBus.begin();
   buttonsMgr.setup();
+  requestsMgr.setup();
 }
 
 void loop()
 {
   controller.tick();
   buttonsMgr.tick();
-
-  Serial.print("Mode: ");
-  Serial.print(controller.showMode());
-  Serial.print(" - IsReady: ");
-  Serial.print(controller.isReady());
-  Serial.print(" - IsStarted: ");
-  Serial.println(controller.isStarted());
+  requestsMgr.tick();
 }

--- a/Config.h
+++ b/Config.h
@@ -22,3 +22,4 @@ uint16_t config_timeRefreshInterval;
 uint8_t config_targetTimeHours;
 uint8_t config_targetTimeMinutes;
 uint8_t config_keepWarmDuration;
+uint8_t config_serverPort;

--- a/Controller.cpp
+++ b/Controller.cpp
@@ -39,7 +39,7 @@ void Controller::tick()
     manage();
 }
 
-String Controller::showMode()
+char* Controller::showMode()
 {
     switch (_mode)
     {

--- a/Controller.h
+++ b/Controller.h
@@ -19,8 +19,7 @@ public:
              uint8_t keepWarmDuration);
   void setup();
   void tick();
-  // TODO: Temporary
-  String showMode();
+  char *showMode();
   bool isReady();
   bool isStarted();
   ControlMode currentMode();

--- a/RequestsMgr.cpp
+++ b/RequestsMgr.cpp
@@ -1,0 +1,128 @@
+/*
+  RequestsMgr.cpp - Support Library to manage http requests.
+*/
+
+#include "RequestsMgr.h"
+#include <ESP8266WebServer.h>
+#include <stdio.h>
+
+// Constructors
+RequestsMgr::RequestsMgr(uint8_t serverPort,
+                         Controller *controller)
+    : _webServer(serverPort),
+      _controller(controller)
+{
+}
+
+// Public
+void RequestsMgr::setup()
+{
+  _webServer.on("/", std::bind(&RequestsMgr::handleRoot, this));
+  _webServer.on("/info", std::bind(&RequestsMgr::handleInfo, this));
+  _webServer.on("/setMode", std::bind(&RequestsMgr::handleSetMode, this));
+  _webServer.onNotFound(std::bind(&RequestsMgr::handleNotFound, this));
+  _webServer.begin();
+}
+
+void RequestsMgr::tick()
+{
+  _webServer.handleClient();
+}
+
+// Private
+void RequestsMgr::handleRoot()
+{
+  _webServer.send(this->OK,
+                  this->CONTENT_TYPE,
+                  "Coffee Machine says hi!");
+}
+
+void RequestsMgr::handleInfo()
+{
+  char res[100];
+  snprintf(res,
+           sizeof(res),
+           "Info:\n-Mode: %s\n-IsReady: %s",
+           _controller->showMode(),
+           _controller->isReady() ? "Yes" : "No");
+
+  _webServer.send(this->OK,
+                  this->CONTENT_TYPE,
+                  res);
+}
+
+void RequestsMgr::handleSetMode()
+{
+  if (_webServer.method() != HTTP_POST)
+  {
+    _webServer.send(this->METHOD_NOT_ALLOWED,
+                    this->CONTENT_TYPE,
+                    "Expecting 'Post'.");
+    return;
+  }
+
+  if (!_webServer.hasArg("controlMode"))
+  {
+    _webServer.send(this->BAD_REQUEST,
+                    this->CONTENT_TYPE,
+                    "Expecting a 'controlMode' argument.");
+    return;
+  }
+
+  const String controlModeArgValue = _webServer.arg("controlMode");
+  char requestedMode[200];
+  controlModeArgValue.toCharArray(requestedMode, sizeof(requestedMode));
+
+  ControlMode nextMode;
+  if (controlModeArgValue == "Off")
+  {
+    nextMode = ControlMode::off;
+  }
+  else if (controlModeArgValue == "Schedule")
+  {
+    nextMode = ControlMode::schedule_check;
+  }
+  else if (controlModeArgValue == "On")
+  {
+    if (!_controller->isReady())
+    {
+      _webServer.send(this->FORBIDDEN,
+                      this->CONTENT_TYPE,
+                      "Machine cannot be started if not physically flagged as ready.");
+      return;
+    }
+    nextMode = ControlMode::on;
+  }
+  else
+  {
+    char res[100];
+    snprintf(res,
+             sizeof(res),
+             "'%s' is not a valid 'controlMode' argument value.",
+             requestedMode);
+
+    _webServer.send(this->BAD_REQUEST,
+                    this->CONTENT_TYPE,
+                    res);
+    return;
+  }
+
+  _controller->setMode(nextMode);
+
+  char res[100];
+  snprintf(res,
+           sizeof(res),
+           "ControlMode '%s' applied.",
+           requestedMode);
+
+  _webServer.send(this->OK,
+                  this->CONTENT_TYPE,
+                  res);
+}
+
+void RequestsMgr::handleNotFound()
+{
+  _webServer.send(this->NOT_FOUND,
+                  this->CONTENT_TYPE,
+                  "Woohaa horsy, coffee machine has no idea what you are on about!");
+}

--- a/RequestsMgr.h
+++ b/RequestsMgr.h
@@ -1,0 +1,37 @@
+/*
+  RequestsMgr.h - Support Library to manage http requests.
+*/
+
+#include "Arduino.h"
+#include "ControlMode.h"
+#include "Controller.h"
+#include <ESP8266WebServer.h>
+#include <ESP8266mDNS.h>
+
+#ifndef RequestsMgr_h
+#define RequestsMgr_h
+
+class RequestsMgr
+{
+public:
+    RequestsMgr(uint8_t serverPort, 
+                Controller *controller);
+    void setup();
+    void tick();
+
+private:
+    ESP8266WebServer _webServer;
+    Controller *_controller;
+    void handleRoot();
+    void handleInfo();
+    void handleSetMode();
+    void handleNotFound();
+    const char* CONTENT_TYPE = "text/plain";
+    const int OK = 200;
+    const int BAD_REQUEST = 400;
+    const int FORBIDDEN = 403;
+    const int NOT_FOUND = 404;
+    const int METHOD_NOT_ALLOWED = 405;
+};
+
+#endif


### PR DESCRIPTION
### Functionality
This provides support for Web requests, so a few endpoints:
- `Get` ->`/`: basic landing page
- `Get` -> `/info`: basic info about the machine's states:
  - Current `ControlMode` state
  - Current `IsReady` state
- `post` -> `/setMode?controlMode=Foo`
  - This support `off`, `schedule` and `on` (but with conditions, see below)

### Considerations
Few "by-design" security limitations:
- You cannot change the `IsReady` state with a request, this has to be done with the physical control panel.
- You can only turn the machine on with a request if the machine is marked as ready.