### PR TITLE
No endpoint splits. Handling for GET/POST and empty parameters.

### DIFF
--- a/RequestsMgr.h
+++ b/RequestsMgr.h
@@ -24,10 +24,13 @@ private:
     Controller *_controller;
     void handleRoot();
     void handleInfo();
-    void handleSetMode();
-    void handleGetSchedule();
-    void handleSetSchedule();
+    void handleControlMode();
+    void handleSchedule();
     void handleNotFound();
+    void getControlMode();
+    void setControlMode();
+    void getSchedule();
+    void setSchedule();
     const char* CONTENT_TYPE = "text/plain";
     const int OK = 200;
     const int BAD_REQUEST = 400;


### PR DESCRIPTION
We used to have separate endpoints to get and set the control mode and schedule.
Not very nice, so now just once endpoint that handles GET & POST verbs.
Also now handling empty parameters rather than just blowing up :)